### PR TITLE
docs: Enforce testing standards for all agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,7 @@
 - Project state belongs in `docs/`, not the Brain
 - Use `[GOSLING2]` or `[GLOBAL]` prefixes for brain operations
 - Search brain when starting sessions or hitting familiar bugs
+
+## 5. Testing and Workflow Standards
+- **CRITICAL:** Before starting ANY implementation or writing ANY tests, you MUST read and follow the rules in `docs/testing/TDD_STANDARD.md` and `docs/testing/JS_TESTING_STANDARD.md`.
+- You must present a feature chain and tests to the user for approval before writing implementation.


### PR DESCRIPTION
Added explicit instructions to `AGENTS.md` to ensure that all future agent sessions read and adhere to the project's Test-Driven Development standards located in `docs/testing/` before starting any implementation.

---
*PR created automatically by Jules for task [5025768381452876962](https://jules.google.com/task/5025768381452876962) started by @PROdotes*